### PR TITLE
Simplify code, remove deprecated jQuery function

### DIFF
--- a/inline-qrcode.js
+++ b/inline-qrcode.js
@@ -15,16 +15,4 @@ function qrcode_code() {
 
 }
 
-$(document).ready( function( ){
-    // Share button behavior
-    $( '.button_share' ).live("click", function( ){
-      console.log('clicked');
-        qrcode_code( );
-    });
-
-    // Tab behavior on stats page
-    $('a[href=#stat_tab_share]').click(function( ){
-        qrcode_code( );
-    });
-});
-
+$(document).ready( function(){ qrcode_code() } );


### PR DESCRIPTION
$.live() is deprecated.

This runs the code each time, regardless of whether the Share button is clicked on the stats page. It is assumed that it won't be used enough to cause an issue. If so, can be rewritten.
